### PR TITLE
Aeson's inferred JSON parsing is so cool

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -1,8 +1,19 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveGeneric, DeriveAnyClass #-}
 
 import Control.Lens
 import Network.Wreq
 import Data.Text as T
+import Data.Aeson
+import GHC.Generics
+
+data RhymebrainResult = RhymebrainResult { score :: Int, word :: T.Text  }
+    deriving (Generic, FromJSON, Show)
+
+sample = "[ {\"word\":\"part\",\"freq\":27,\"score\":300,\"flags\":\"bc\",\"syllables\":\"1\"} ]"
+
+decodeSample :: Maybe [RhymebrainResult]
+decodeSample = decode sample
 
 rhymebrainOptions :: T.Text -> Options
 rhymebrainOptions word = defaults &
@@ -17,4 +28,5 @@ rhymebrainHost = "http://rhymebrain.com/talk"
 main = do
     let word = "heart"
     r <- getWith (rhymebrainOptions word) rhymebrainHost
-    print $ r ^. responseBody
+    -- print $ r ^. responseBody
+    print $ decodeSample

--- a/girls-just-want-to-have-punctors.cabal
+++ b/girls-just-want-to-have-punctors.cabal
@@ -23,6 +23,7 @@ executable girls-just-want-to-have-punctors
                , wreq
                , lens
                , text
+               , aeson
 
   -- hs-source-dirs:
   default-language:    Haskell2010


### PR DESCRIPTION
We use record syntax to give names to the `RhymebrainResult` JSON object fields that we want to pull out: `score` and `word`.

With just the names of the fields, Aeson + GHC's generics can auto-derive a JSON parser so that `decode sample` Just Works.
