### PR TITLE
Pull out the highest-scoring words from RhymeBrain

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -32,8 +32,8 @@ resultsWithScore :: Int -> [RhymebrainResult] -> [RhymebrainResult]
 resultsWithScore s = filter (\result -> score result == s)
 
 main = do
-    let word = "heart"
-    r <- rhymebrainResults word
+    let originalWord = "heart"
+    r <- rhymebrainResults originalWord
     let results = r ^. responseBody
     let highestScoring = resultsWithScore (score $ maximum results) results
-    print $ highestScoring
+    print $ map word highestScoring

--- a/Main.hs
+++ b/Main.hs
@@ -3,7 +3,7 @@
 
 import Control.Lens
 import Network.Wreq
-import Data.Text as T
+import Data.Text as T (Text)
 import Data.Aeson
 import GHC.Generics
 

--- a/Main.hs
+++ b/Main.hs
@@ -10,10 +10,6 @@ import GHC.Generics
 data RhymebrainResult = RhymebrainResult { score :: Int, word :: T.Text  }
     deriving (Generic, FromJSON, Show)
 
-sample = "[ {\"word\":\"part\",\"freq\":27,\"score\":300,\"flags\":\"bc\",\"syllables\":\"1\"} ]"
-
-decodeSample :: Maybe [RhymebrainResult]
-decodeSample = decode sample
 
 rhymebrainOptions :: T.Text -> Options
 rhymebrainOptions word = defaults &

--- a/Main.hs
+++ b/Main.hs
@@ -6,10 +6,13 @@ import Network.Wreq
 import Data.Text as T (Text)
 import Data.Aeson
 import GHC.Generics
+import Data.Function (on)
 
 data RhymebrainResult = RhymebrainResult { score :: Int, word :: T.Text  }
-    deriving (Generic, FromJSON, Show)
+    deriving (Generic, FromJSON, Show, Eq)
 
+instance Ord RhymebrainResult where
+    compare = compare `on` score
 
 rhymebrainOptions :: T.Text -> Options
 rhymebrainOptions word = defaults &

--- a/Main.hs
+++ b/Main.hs
@@ -7,6 +7,7 @@ import Data.Text as T (Text)
 import Data.Aeson
 import GHC.Generics
 import Data.Function (on)
+import Data.List (maximumBy)
 
 data RhymebrainResult = RhymebrainResult { score :: Int, word :: T.Text  }
     deriving (Generic, FromJSON, Show, Eq)
@@ -24,8 +25,15 @@ rhymebrainOptions word = defaults &
 rhymebrainHost :: String
 rhymebrainHost = "http://rhymebrain.com/talk"
 
+rhymebrainResults :: T.Text -> IO (Response [RhymebrainResult])
+rhymebrainResults word = asJSON =<< getWith (rhymebrainOptions word) rhymebrainHost
+
+resultsWithScore :: Int -> [RhymebrainResult] -> [RhymebrainResult]
+resultsWithScore s = filter (\result -> score result == s)
+
 main = do
     let word = "heart"
-    r <- getWith (rhymebrainOptions word) rhymebrainHost
-    -- print $ r ^. responseBody
-    print $ decodeSample
+    r <- rhymebrainResults word
+    let results = r ^. responseBody
+    let highestScoring = resultsWithScore (score $ maximum results) results
+    print $ highestScoring


### PR DESCRIPTION
Of note:
- `instance Ord RhymebrainResult` to sort by score so `maximum` works
- `rhymebrainResults` returns `IO (Response [RhymebrainResult])`, which is enough for Aeson's `asJSON` function to know to decode the raw response JSON into `[RhymebrainResult]`
- `Data.Function.on`, which provides a handy way to write a `compare` function
