### PR TITLE
Filter phrases to ones with rhymes

### DIFF
--- a/girls-just-want-to-have-punctors.cabal
+++ b/girls-just-want-to-have-punctors.cabal
@@ -24,6 +24,8 @@ executable girls-just-want-to-have-punctors
                , lens
                , text
                , aeson
+               , regex-pcre
+               , bytestring
 
   -- hs-source-dirs:
   default-language:    Haskell2010


### PR DESCRIPTION
It filters the giant list of phrases to ones that match any of the rhymes.

To avoid `martini` matching `mart`, we use `Text.Regex.PCRE` to ensure that we match on word boundaries.
