### PR TITLE
Case-insensitively match rhymes to phrases

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -65,8 +65,8 @@ containsAnyOf :: [T.Text] -> T.Text -> Bool
 containsAnyOf rhymes phrase = t2b phrase =~ anyRhyme
     where
         anyRhyme = t2b $ withWordBoundaries $ T.intercalate "|" rhymes
-        -- Turn "hey" into "\\b(hey)\\b"
-        withWordBoundaries t = "\\b(" <> t <> ")\\b"
+        -- Turn "hey" into "(?i)\\b(hey)\\b"
+        withWordBoundaries t = "(?i)\\b(" <> t <> ")\\b"
 
 main = do
     let originalWord = "heart"


### PR DESCRIPTION
`(?i)` is a fairly standard regex flag that means "match case-insensitively".

For example, it works in [Python](https://docs.python.org/2/library/re.html) and [Ruby](http://ruby-doc.org/core-2.2.3/Regexp.html#class-Regexp-label-Options).
